### PR TITLE
unmount React Component after each test

### DIFF
--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -1,5 +1,6 @@
 /// <reference path="../src/interfaces/interfaces.d.ts" />
 
+import { unmountComponentAtNode } from 'react-dom';
 import thunk from "redux-thunk";
 // import * as createLogger from "redux-logger";
 import * as $ from "jquery";
@@ -7,8 +8,10 @@ import { expect } from "chai";
 import bootstrap from "../src/index";
 import { getRoutes, getReducers } from "./stubs";
 
+const CONTAINER_ID = "root";
+
 history.pushState({}, "", "/");
-$("body").append(`<div id="root"/><div>`);
+$("body").append(`<div id="${CONTAINER_ID}"/><div>`);
 
 describe("redux-bootstrap", () => {
 
@@ -38,13 +41,23 @@ describe("redux-bootstrap", () => {
 
     describe("Should be able to bootstrap applications.", () => {
 
-        bootstrap({
-            container: "root",
-            initialState: {},
-            middlewares: [thunk],
-            reducers: getReducers(),
-            routes: getRoutes()
+        before(() => {
+            bootstrap({
+                container: "root",
+                initialState: {},
+                middlewares: [thunk],
+                reducers: getReducers(),
+                routes: getRoutes()
+            });
+
         });
+
+        after(() => {
+            // https://facebook.github.io/react/docs/top-level-api.html#reactdom.unmountcomponentatnode
+            const rootNode = document.getElementById(CONTAINER_ID);
+            unmountComponentAtNode(rootNode);
+        });
+
 
         it("Should be able to render the home page.", (done) => {
             setTimeout(() => {
@@ -104,6 +117,34 @@ describe("redux-bootstrap", () => {
 
             }, 30);
 
+        });
+
+    });
+
+    describe("Should be able to bootstrap again.", () => {
+
+        let result: BootstrapResult;
+        before(() => {
+            result = bootstrap({
+                container: "root",
+                initialState: {},
+                middlewares: [thunk],
+                reducers: getReducers(),
+                routes: getRoutes()
+            });
+        });
+
+
+        it("Should expose history, root, store in result.", () => {
+            expect(result).to.be.ok;
+            expect(result).to.have.property("history");
+            expect(result).to.have.property("root");
+            expect(result).to.have.property("store");
+        });
+
+        after(() => {
+            const rootNode = document.getElementById(CONTAINER_ID);
+            unmountComponentAtNode(rootNode);
         });
 
     });


### PR DESCRIPTION
## Description

- use [`ReactDOM.unmountComponentAtNode()`](https://facebook.github.io/react/docs/top-level-api.html#reactdom.unmountcomponentatnode) to clean up in between tests

- use [`before()` and `after()`](https://mochajs.org/#hooks) Mocha hooks to ensure test sequence

## Related Issue

- may mean that we don't need #11 to proceed

## Motivation and Context

- provides an approach to having sufficient isolation for testing upcoming features

## How Has This Been Tested?

- `npm test` passes, and this is a test-only change

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to the type definitions.
- [ ] I have updated the type definitions accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

