### PR TITLE
support `bootstrap()` with custom history and related options

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/remojansen/redux-bootstrap#readme",
   "dependencies": {
+    "history": "^2.1.1",
     "immutable": "^3.7.6",
     "react": "^15.0.1",
     "react-dom": "^15.0.1",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { render } from "react-dom";
-import createBrowserHistory from "history/lib/createBrowserHistory";
+import { createHistory as createBrowserHistory } from "history";
 import { useRouterHistory } from "react-router";
 import { LOCATION_CHANGE, syncHistoryWithStore, routerMiddleware } from "react-router-redux";
 import { combineReducers } from "redux-immutable";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,7 +2,8 @@
 
 import * as React from "react";
 import { render } from "react-dom";
-import { browserHistory } from "react-router";
+import createBrowserHistory from "history/lib/createBrowserHistory";
+import { useRouterHistory } from "react-router";
 import { LOCATION_CHANGE, syncHistoryWithStore, routerMiddleware } from "react-router-redux";
 import { combineReducers } from "redux-immutable";
 import { createSelector } from "reselect";
@@ -38,6 +39,8 @@ function bootstrap(options: BoostrapOptions): BootstrapResult {
 
     // optional
     let container = options.container || "root";
+    const createHistory = options.createHistory || createBrowserHistory;
+    const historyOptions = options.historyOptions || {};
     let initialState = options.initialState || {};
     let immutableInitialState = Immutable.fromJS(initialState);
     let middlewares = options.middlewares || [];
@@ -47,11 +50,12 @@ function bootstrap(options: BoostrapOptions): BootstrapResult {
     let rootReducer = combineReducers(reducers);
 
     // Configure store
-    let routerMddlwr: Redux.Middleware = routerMiddleware(browserHistory);
+    const routerHistory = useRouterHistory(createHistory)(historyOptions);
+    let routerMddlwr: Redux.Middleware = routerMiddleware(routerHistory);
     const store = configureStore([...middlewares, routerMddlwr], rootReducer, immutableInitialState);
 
     // Create an enhanced history that syncs navigation events with the store
-    const history = syncHistoryWithStore(browserHistory, store, {
+    const history = syncHistoryWithStore(routerHistory, store, {
         selectLocationState: createSelector(getRouting, (routing) => routing.toJS())
     });
 

--- a/src/interfaces/interfaces.d.ts
+++ b/src/interfaces/interfaces.d.ts
@@ -4,6 +4,8 @@
 interface BoostrapOptions {
     routes: JSX.Element;
     reducers: ReducersOption;
+    createHistory?: HistoryModule.CreateHistory<HistoryModule.History>;
+    historyOptions?: HistoryModule.HistoryOptions;
     middlewares?: Redux.Middleware[];
     initialState?: any;
     container?: string;

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -1,5 +1,6 @@
 /// <reference path="../src/interfaces/interfaces.d.ts" />
 
+import { createHashHistory } from "history";
 import { unmountComponentAtNode } from 'react-dom';
 import thunk from "redux-thunk";
 // import * as createLogger from "redux-logger";
@@ -58,6 +59,7 @@ describe("redux-bootstrap", () => {
             // https://facebook.github.io/react/docs/top-level-api.html#reactdom.unmountcomponentatnode
             const rootNode = document.getElementById(CONTAINER_ID);
             unmountComponentAtNode(rootNode);
+            rootNode.innerHTML = "";
         });
 
 
@@ -147,6 +149,45 @@ describe("redux-bootstrap", () => {
         after(() => {
             const rootNode = document.getElementById(CONTAINER_ID);
             unmountComponentAtNode(rootNode);
+            rootNode.innerHTML = "";
+       });
+
+    });
+
+    describe("Should be able to bootstrap with hashHistory.", () => {
+
+        let result: BootstrapResult;
+        before(() => {
+            result = bootstrap({
+                container: "root",
+                initialState: {},
+                createHistory: createHashHistory,
+                middlewares: [thunk],
+                reducers: getReducers(),
+                routes: getRoutes()
+            });
+        });
+
+        it("Should be able to render the home page.", (done) => {
+            setTimeout(() => {
+                expect($("#home_page_title").text()).eql("Home Page!");
+                done();
+            }, 20);
+        });
+
+        it("Should be able to navigate to a page.", (done) => {
+            let usersLink = document.getElementById("link_to_users");
+            usersLink.click();
+            setTimeout(() => {
+                expect($("#users_page_title").text()).eql("Users Page!");
+                done();
+            }, 30);
+        });
+
+        after(() => {
+            const rootNode = document.getElementById(CONTAINER_ID);
+            unmountComponentAtNode(rootNode);
+            rootNode.innerHTML = "";
         });
 
     });

--- a/type_definitions/redux-bootstrap/redux-bootstrap-tests.tsx
+++ b/type_definitions/redux-bootstrap/redux-bootstrap-tests.tsx
@@ -2,7 +2,7 @@
 /// <reference path="../react/react.d.ts" />
 /// <reference path="./redux-bootstrap.d.ts" />
 
-import bootstrap from "redux-bootstrap";
+import { bootstrap } from "redux-bootstrap";
 
 let routes: JSX.Element = null;
 

--- a/type_definitions/redux-bootstrap/redux-bootstrap.d.ts
+++ b/type_definitions/redux-bootstrap/redux-bootstrap.d.ts
@@ -5,7 +5,6 @@
 
 /// <reference path="../redux/redux.d.ts" />
 /// <reference path="../react/react.d.ts" />
-/// <reference path="../react-router-redux/react-router-redux.d.ts" />
 
 declare module "redux-bootstrap" {
 

--- a/type_definitions/redux-bootstrap/redux-bootstrap.d.ts
+++ b/type_definitions/redux-bootstrap/redux-bootstrap.d.ts
@@ -12,6 +12,8 @@ declare module "redux-bootstrap" {
     interface BoostrapOptions {
         routes: JSX.Element;
         reducers: ReducersOption;
+        createHistory?: HistoryModule.CreateHistory<HistoryModule.History>;
+        historyOptions?: HistoryModule.HistoryOptions;
         middlewares?: Redux.Middleware[];
         initialState?: any;
         container?: string;


### PR DESCRIPTION
## Description

- add createHistory and historyOptions options to `bootstrap()`

## Related Issue

- fixes #10 

## Motivation and Context

- gives us new avenues for testing (e.g. mocked history)

- gives consumers ability to use alternative history providers (e.g. memory or hash)

## How Has This Been Tested?

- `npm test` passes with PhantomJS and Chrome

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to the type definitions.
- [ ] I have updated the type definitions accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

