### PR TITLE
server rendering: new "render" option, and new "output" in result

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,12 @@ import reposReducer from "./reducers/reposReducer";
 
 bootstrap({
     container: "root",                    // optional
+    createHistory: createBrowserHistory,  // optional
+    historyOptions: {},                   // optional
     initialState: {},                     // optional
-    middlewares: [thunk, createLogger()], // optional
+    middlewares: [thunk, createLogger()], // optional    
+    render: ReactDOM.render,              // optional
+    
     reducers: {
         usersReducer,
         reposReducer,
@@ -124,6 +128,7 @@ The `result` object returned by the bootstrap function provides access to the st
 interface BootstrapResult {
     store: Redux.Store,
     history: ReactRouterRedux.ReactRouterReduxHistory,
+    output: any, // value returned by render()
     root: JSX.Element
 }
 ```

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -56,7 +56,7 @@ function bootstrap(options: BoostrapOptions): BootstrapResult {
 
     // Create an enhanced history that syncs navigation events with the store
     const history = syncHistoryWithStore(routerHistory, store, {
-        selectLocationState: createSelector(getRouting, (routing) => routing.toJS())
+        selectLocationState: createSelector(getRouting, (routing: any) => routing.toJS())
     });
 
     // root component

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 /// <reference path="./interfaces/interfaces.d.ts" />
 
 import * as React from "react";
-import { render } from "react-dom";
+import { render as renderToDOM } from "react-dom";
 import { createHistory as createBrowserHistory } from "history";
 import { useRouterHistory } from "react-router";
 import { LOCATION_CHANGE, syncHistoryWithStore, routerMiddleware } from "react-router-redux";
@@ -44,6 +44,7 @@ function bootstrap(options: BoostrapOptions): BootstrapResult {
     let initialState = options.initialState || {};
     let immutableInitialState = Immutable.fromJS(initialState);
     let middlewares = options.middlewares || [];
+    const render = options.render || renderToDOM;
 
     // Define the root reducer
     reducers.routing = routerReducer;
@@ -63,7 +64,7 @@ function bootstrap(options: BoostrapOptions): BootstrapResult {
     let root = getRoot(store, history, routes);
 
     // Render Root coponent
-    render(
+    const output = render(
         root,
         document.getElementById(container)
     );
@@ -71,6 +72,7 @@ function bootstrap(options: BoostrapOptions): BootstrapResult {
     return {
         store,
         history,
+        output,
         root
     };
 

--- a/src/interfaces/interfaces.d.ts
+++ b/src/interfaces/interfaces.d.ts
@@ -7,6 +7,7 @@ interface BoostrapOptions {
     createHistory?: HistoryModule.CreateHistory<HistoryModule.History>;
     historyOptions?: HistoryModule.HistoryOptions;
     middlewares?: Redux.Middleware[];
+    render?: Function;
     initialState?: any;
     container?: string;
 }
@@ -14,6 +15,7 @@ interface BoostrapOptions {
 interface BootstrapResult {
     store: Redux.Store;
     history: ReactRouterRedux.ReactRouterReduxHistory;
+    output: any;
     root: JSX.Element;
 }
 

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -1,7 +1,8 @@
 /// <reference path="../src/interfaces/interfaces.d.ts" />
 
-import { createHashHistory } from "history";
-import { unmountComponentAtNode } from 'react-dom';
+import { createHashHistory, createMemoryHistory } from "history";
+import { unmountComponentAtNode } from "react-dom";
+import { renderToStaticMarkup } from "react-dom/server";
 import thunk from "redux-thunk";
 // import * as createLogger from "redux-logger";
 import { push } from "react-router-redux";
@@ -160,8 +161,8 @@ describe("redux-bootstrap", () => {
         before(() => {
             result = bootstrap({
                 container: "root",
-                initialState: {},
                 createHistory: createHashHistory,
+                initialState: {},
                 middlewares: [thunk],
                 reducers: getReducers(),
                 routes: getRoutes()
@@ -250,6 +251,53 @@ describe("redux-bootstrap", () => {
         after(() => {
             const rootNode = document.getElementById(CONTAINER_ID);
             unmountComponentAtNode(rootNode);
+        });
+
+    });
+
+    describe("Should bootstrap with memoryHistory and renderToStaticMarkup.", () => {
+
+        let result: BootstrapResult;
+        before(() => {
+            result = bootstrap({
+                container: "root",
+                createHistory: createMemoryHistory,
+                initialState: {},
+                middlewares: [thunk],
+                reducers: getReducers(),
+                render: renderToStaticMarkup,
+                routes: getRoutes()
+            });
+            result.output = renderToStaticMarkup(result.root);
+        });
+
+        it("Should be able to render the home page to string.", () => {
+            expect(result.output).to.be.string;
+            expect(result.output).to.include('<div id="home_page_title">Home Page!</div>');
+        });
+
+    });
+
+    describe("Should bootstrap with memoryHistory and renderToStaticMarkup, with navigation.", () => {
+
+        let result: BootstrapResult;
+        before(() => {
+            result = bootstrap({
+                container: "root",
+                createHistory: createMemoryHistory,
+                initialState: {},
+                middlewares: [thunk],
+                reducers: getReducers(),
+                render: () => {}, // skip first render, we navigate first
+                routes: getRoutes()
+            });
+            result.history.push("/users");
+            result.output = renderToStaticMarkup(result.root);
+        });
+
+        it("Should be able to render the users page to string.", () => {
+            expect(result.output).to.be.string;
+            expect(result.output).to.include('<div id="users_page_title">Users Page!</div>');
         });
 
     });

--- a/type_definitions/redux-bootstrap/redux-bootstrap.d.ts
+++ b/type_definitions/redux-bootstrap/redux-bootstrap.d.ts
@@ -14,6 +14,7 @@ declare module "redux-bootstrap" {
         createHistory?: HistoryModule.CreateHistory<HistoryModule.History>;
         historyOptions?: HistoryModule.HistoryOptions;
         middlewares?: Redux.Middleware[];
+        render?: Function;
         initialState?: any;
         container?: string;
     }
@@ -21,6 +22,7 @@ declare module "redux-bootstrap" {
     interface BootstrapResult {
         store: Redux.Store;
         history: ReactRouterRedux.ReactRouterReduxHistory;
+        output: any;
         root: JSX.Element;
     }
 


### PR DESCRIPTION
## Description

- new "render" option for `bootstrap()` allows a consumer to pass in a custom render function, e.g. [`ReactDOMServer.renderToString()`](https://facebook.github.io/react/docs/top-level-api.html#reactdomserver.rendertostring)

- new "output" property returned by `bootstrap()` provides the output from `render()`

## Related Issue

- when documentation is included, this fixes #9 

- should be `git rebase`ed after #14 is merged

## Motivation and Context

- by making the render process configurable, we allow `bootstrap()` to be used for server rendering use cases

## How Has This Been Tested?

- `npm test` passes

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] My change requires a change to the type definitions.
- [x] I have updated the type definitions accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
