### PR TITLE
syncHistoryWithStore uses a caching selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ The preceding command will install `redux-bootstrap` and the following dependenc
     "redux-devtools": "^3.2.0",
     "redux-devtools-dock-monitor": "^1.1.1",
     "redux-devtools-log-monitor": "^1.0.10",
-    "redux-immutable": "^3.0.6"
+    "redux-immutable": "^3.0.6",
+    "reselect": "^2.5.1"
 }
 ```
  

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "redux-devtools": "^3.2.0",
     "redux-devtools-dock-monitor": "^1.1.1",
     "redux-devtools-log-monitor": "^1.0.10",
-    "redux-immutable": "^3.0.6"
+    "redux-immutable": "^3.0.6",
+    "reselect": "^2.5.1"
   },
   "devDependencies": {
     "browserify": "^13.0.0",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,7 @@ import { render } from "react-dom";
 import { browserHistory } from "react-router";
 import { LOCATION_CHANGE, syncHistoryWithStore, routerMiddleware } from "react-router-redux";
 import { combineReducers } from "redux-immutable";
+import { createSelector } from "reselect";
 import * as Immutable from "immutable";
 import getRoot from "./containers/root";
 import configureStore from "./store/configure_store";
@@ -13,7 +14,7 @@ const initialRouterReducerState = Immutable.fromJS({
     locationBeforeTransitions: null
 });
 
-let routerReducer = (state = initialRouterReducerState, action: any) => {
+const routerReducer = (state = initialRouterReducerState, action: any) => {
     if (action.type === LOCATION_CHANGE) {
         return state.merge({
             locationBeforeTransitions: action.payload
@@ -21,6 +22,8 @@ let routerReducer = (state = initialRouterReducerState, action: any) => {
     }
     return state;
 };
+
+const getRouting = (state: any) => state.get("routing");
 
 function bootstrap(options: BoostrapOptions): BootstrapResult {
 
@@ -49,7 +52,7 @@ function bootstrap(options: BoostrapOptions): BootstrapResult {
 
     // Create an enhanced history that syncs navigation events with the store
     const history = syncHistoryWithStore(browserHistory, store, {
-        selectLocationState: (state: any) => state.get("routing").toJS()
+        selectLocationState: createSelector(getRouting, (routing) => routing.toJS())
     });
 
     // root component

--- a/test/stubs.tsx
+++ b/test/stubs.tsx
@@ -53,11 +53,12 @@ class Home extends React.Component<any, any> {
 // ******************************************************************************
 // * CONSTANTS
 // ******************************************************************************
-const ACTION_TYPES = {
+export const ACTION_TYPES = {
     ADD_REPO_BEGIN: "ADD_REPO_BEGIN",
     ADD_REPO_SUCCESS: "ADD_REPO_SUCCESS",
     ADD_USER_BEGIN: "ADD_USER_BEGIN",
-    ADD_USER_SUCCESS: "ADD_USER_SUCCESS"
+    ADD_USER_SUCCESS: "ADD_USER_SUCCESS",
+    BUMP_COUNTER: "BUMP_COUNTER"
 };
 
 // ******************************************************************************
@@ -167,6 +168,15 @@ function getRoutes() {
 // * REDUCERS
 // ******************************************************************************
 function getReducers(): ReducersOption {
+
+    const counterReducer: Redux.Reducer = (previousState: any = 0, action: any) => {
+        switch (action.type) {
+            case ACTION_TYPES.BUMP_COUNTER:
+                return previousState + 1;
+            default:
+                return previousState;
+        }
+    };
 
     const defaultUsersState = Immutable.fromJS({
         loading: false,


### PR DESCRIPTION
## Description

- depend on [reactjs/reselect](https://github.com/reactjs/reselect)

- use it to build a caching selector to retrieve react-router's state from the store

- use this caching selector with syncHistoryWithStore

## Related Issue

- fixes #2 

## Motivation and Context

- without this, every change to the store results in a call to all `history.listen()` listeners (i.e. react-router)

- with this fix, these listeners are called far fewer times, leading to more efficient synchronisation

## How Has This Been Tested?

- new tests confirm that navigation still causes expected calls to history listeners

- new tests confirm that non-navigation actions do not cause an equivalent number of calls to history listeners

- `npm test` passes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] My change requires a change to the type definitions.
- [ ] I have updated the type definitions accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
